### PR TITLE
Handle ERR_CMD_UNKNOWN in GET_COMM_MODE_INFO 

### DIFF
--- a/pyxcp/errormatrix.py
+++ b/pyxcp/errormatrix.py
@@ -146,6 +146,7 @@ ERROR_MATRIX = {
     Command.GET_COMM_MODE_INFO: {
         XcpError.ERR_TIMEOUT: ((PreAction.SYNCH,), Action.REPEAT_2_TIMES),
         XcpError.ERR_CMD_BUSY: ((PreAction.WAIT_T7), Action.REPEAT_INF_TIMES),
+        XcpError.ERR_CMD_UNKNOWN: ((PreAction.NONE), Action.DISPLAY_ERROR),
         XcpError.ERR_CMD_SYNTAX: ((PreAction.NONE), Action.RETRY_SYNTAX),
         XcpError.ERR_RESOURCE_TEMPORARY_NOT_ACCESSIBLE: (PreAction.NONE, Action.SKIP),
     },


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

According to the XCP spec, the GET_COMM_MODE_INFO command is optional. I noticed that an error handler for ERR_CMD_UNKNOWN was present for all other optional commands, but missing for this one. So, I've added it accordingly.